### PR TITLE
LockGuard component to disable timeout lock

### DIFF
--- a/src/renderer/actions/application.js
+++ b/src/renderer/actions/application.js
@@ -9,6 +9,11 @@ export const lock = createAction("APPLICATION_SET_DATA", () => ({
   isLocked: true,
   hasPassword: true,
 }));
+
+export const disableLock = createAction("APPLICATION_SET_DATA", (lockDisabled: boolean) => ({
+  lockDisabled,
+}));
+
 export const setHasPassword = createAction("APPLICATION_SET_DATA", hasPassword => ({
   hasPassword,
 }));

--- a/src/renderer/components/Idler.js
+++ b/src/renderer/components/Idler.js
@@ -6,12 +6,13 @@ import { autoLockTimeoutSelector } from "~/renderer/reducers/settings";
 import { lock } from "~/renderer/actions/application";
 
 import { useDebouncedCallback } from "~/renderer/hooks/useDebounce";
-import { hasPasswordSelector } from "~/renderer/reducers/application";
+import { hasPasswordSelector, isLockDisabled } from "~/renderer/reducers/application";
 
 const Idler = () => {
   const [lastAction, setLastAction] = useState(-1);
   const autoLockTimeout = useSelector(autoLockTimeoutSelector);
   const hasPassword = useSelector(hasPasswordSelector);
+  const disabledLock = useSelector(isLockDisabled);
   const dispatch = useDispatch();
 
   const debounceOnChange = useDebouncedCallback(() => setLastAction(Date.now()), 1000, {
@@ -34,7 +35,7 @@ const Idler = () => {
   useEffect(() => {
     let timeout = null;
 
-    if (hasPassword && autoLockTimeout && autoLockTimeout !== -1) {
+    if (!disabledLock && hasPassword && autoLockTimeout && autoLockTimeout !== -1) {
       timeout = setTimeout(() => {
         dispatch(lock());
       }, autoLockTimeout * 60000);
@@ -45,7 +46,7 @@ const Idler = () => {
         clearTimeout(timeout);
       }
     };
-  }, [lastAction, autoLockTimeout, hasPassword, dispatch]);
+  }, [disabledLock, lastAction, autoLockTimeout, hasPassword, dispatch]);
 
   return null;
 };

--- a/src/renderer/components/LockGuard.js
+++ b/src/renderer/components/LockGuard.js
@@ -1,0 +1,22 @@
+// @flow
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import { disableLock } from "~/renderer/actions/application";
+
+type Props = {
+  /** set to true if lock should be guarded */
+  when: boolean,
+};
+
+const LockGuard = ({ when }: Props) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(disableLock(when));
+  }, [dispatch, when]);
+
+  return null;
+};
+
+export default LockGuard;

--- a/src/renderer/reducers/application.js
+++ b/src/renderer/reducers/application.js
@@ -7,6 +7,7 @@ import type { LangAndRegion } from "~/renderer/reducers/settings";
 
 export type ApplicationState = {
   isLocked?: boolean,
+  lockDisabled?: boolean,
   hasPassword?: boolean,
   osDarkMode?: boolean,
   osLanguage?: LangAndRegion,
@@ -41,6 +42,8 @@ const handlers = {
 export const isLocked = (state: Object) => state.application.isLocked === true;
 
 export const hasPasswordSelector = (state: Object) => state.application.hasPassword === true;
+
+export const isLockDisabled = (state: Object) => state.application.lockDisabled;
 
 export const osDarkModeSelector = (state: Object) => state.application.osDarkMode;
 

--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -23,6 +23,7 @@ import AppDepsInstallModal from "./AppDepsInstallModal";
 import AppDepsUnInstallModal from "./AppDepsUnInstallModal";
 
 import ErrorModal from "~/renderer/modals/ErrorModal/index";
+import LockGuard from "~/renderer/components/LockGuard";
 
 const Container = styled.div`
   display: flex;
@@ -89,6 +90,7 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
       {currentError && (
         <ErrorModal isOpened={!!currentError} error={currentError.error} onClose={onCloseError} />
       )}
+      <LockGuard when={jobInProgress} />
       <NavigationGuard
         analyticsName="ManagerGuardModal"
         when={jobInProgress}


### PR DESCRIPTION
Added LockGuard component to disable timeout lock at critical points.
Used in manager during install and uninstalls

### Type
Feature

### Text plan
* Setup a password
* Set lock timeout to 1 min
* Go to manager and start at least 6 or more installs (on nanoX preferably)
* stop touching the page and put the mouse away
* Check that all install finish correctly and that the app locks 1min after last install