### PR TITLE
LL-5788 (Platform): sign transaction show errors

### DIFF
--- a/src/renderer/modals/SignTransaction/index.js
+++ b/src/renderer/modals/SignTransaction/index.js
@@ -5,17 +5,21 @@ import Modal from "~/renderer/components/Modal";
 import Body from "./Body";
 import type { StepId } from "./types";
 
-class SignTransactionModal extends PureComponent<{}, { stepId: StepId }> {
+class SignTransactionModal extends PureComponent<{}, { stepId: StepId, error?: Error }> {
   state = {
     stepId: "amount",
+    error: undefined,
   };
 
   handleReset = () =>
     this.setState({
       stepId: "amount",
+      error: undefined,
     });
 
   handleStepChange = (stepId: StepId) => this.setState({ stepId });
+
+  setError = (error?: Error) => this.setState({ error });
 
   render() {
     const { stepId } = this.state;
@@ -32,10 +36,11 @@ class SignTransactionModal extends PureComponent<{}, { stepId: StepId }> {
             stepId={stepId}
             onClose={() => {
               if (data.onCancel) {
-                data.onCancel();
+                data.onCancel(this.state.error);
               }
               onClose();
             }}
+            setError={this.setError}
             onChangeStepId={this.handleStepChange}
             params={data || {}}
           />

--- a/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
@@ -69,6 +69,7 @@ export default function StepConnectDevice({
           onTransactionSigned(signedOperation);
         } else if (transactionSignError) {
           onTransactionError(transactionSignError);
+          transitionTo("confirmation");
         }
       }}
     />

--- a/src/renderer/modals/SignTransaction/steps/StepAmount.js
+++ b/src/renderer/modals/SignTransaction/steps/StepAmount.js
@@ -79,7 +79,7 @@ export class StepAmountFooter extends PureComponent<StepProps> {
           <BuyButton currency={mainAccount.currency} account={mainAccount} />
         ) : null}
         <Button
-          id={"send-amount-continue-button"}
+          id={"sign-transaction-amount-continue-button"}
           isLoading={bridgePending}
           primary
           disabled={!canNext}

--- a/src/renderer/modals/SignTransaction/steps/StepConfirmation.js
+++ b/src/renderer/modals/SignTransaction/steps/StepConfirmation.js
@@ -1,0 +1,69 @@
+// @flow
+
+import React from "react";
+import styled, { withTheme } from "styled-components";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import Box from "~/renderer/components/Box";
+import RetryButton from "~/renderer/components/RetryButton";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+
+import type { StepProps } from "../types";
+
+const Container: ThemedComponent<{ shouldSpace?: boolean }> = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "palette.text.shade100",
+}))`
+  justify-content: ${p => (p.shouldSpace ? "space-between" : "center")};
+  min-height: 220px;
+`;
+
+function StepConfirmation({ account, t, error, theme, device }: StepProps & { theme: * }) {
+  const currency = account && getAccountCurrency(account);
+  const currencyName = currency?.name ?? "";
+
+  if (error) {
+    return (
+      <Container>
+        <TrackPage
+          category="Sign Transaction Flow"
+          name="Step Confirmation Error"
+          currencyName={currencyName}
+        />
+        <ErrorDisplay error={error} withExportLogs />
+      </Container>
+    );
+  }
+
+  return null;
+}
+
+export function StepConfirmationFooter({
+  t,
+  transitionTo,
+  account,
+  parentAccount,
+  onRetry,
+  error,
+  openModal,
+  closeModal,
+}: StepProps) {
+  return (
+    <>
+      {error ? (
+        <RetryButton
+          ml={2}
+          primary
+          onClick={() => {
+            onRetry();
+            transitionTo("amount");
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export default withTheme(StepConfirmation);

--- a/src/renderer/modals/SignTransaction/steps/StepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/StepConnectDevice.js
@@ -16,7 +16,7 @@ export default function StepConnectDevice({
 }: StepProps) {
   return (
     <>
-      <TrackPage category="Send Flow" name="Step ConnectDevice" />
+      <TrackPage category="Sign Transaction Flow" name="Step ConnectDevice" />
       <GenericStepConnectDevice
         account={account}
         useApp={useApp}

--- a/src/renderer/modals/SignTransaction/types.js
+++ b/src/renderer/modals/SignTransaction/types.js
@@ -7,12 +7,11 @@ import type {
   AccountLike,
   Transaction,
   TransactionStatus,
-  Operation,
   SignedOperation,
 } from "@ledgerhq/live-common/lib/types";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import type { Step } from "~/renderer/components/Stepper";
-export type StepId = "amount" | "device";
+export type StepId = "amount" | "device" | "confirmation";
 
 export type StepProps = {
   t: TFunction,
@@ -27,7 +26,6 @@ export type StepProps = {
   bridgePending: boolean,
   error: ?Error,
   warning: ?Error,
-  optimisticOperation: ?Operation,
   closeModal: void => void,
   openModal: (string, any) => void,
   onChangeAccount: (?AccountLike, ?Account) => void,

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -308,11 +308,7 @@
         ]
       },
       "changelly": {
-        "bullets": [
-          "BTC, ETH, USDT and 50+ others",
-          "Multi-currency",
-          "Centralized"
-        ]
+        "bullets": ["BTC, ETH, USDT and 50+ others", "Multi-currency", "Centralized"]
       },
       "paraswap": {
         "bullets": [
@@ -1492,6 +1488,9 @@
     "footer": {
       "estimatedFees": "Network fees"
     }
+  },
+  "sign": {
+    "title": "Sign transaction"
   },
   "releaseNotes": {
     "title": "Release notes",


### PR DESCRIPTION
(Platform): sign transaction show errors during flow and return them if flow is canceled

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-5788]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Platform sign tx flow if error occurs should show them to the user now